### PR TITLE
Add upvote support and show upvote counts

### DIFF
--- a/app/apps/page.tsx
+++ b/app/apps/page.tsx
@@ -90,10 +90,11 @@ export default function Apps() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {data.map((app) => {
                 const item: AppCardProps = {
-                  id: app.id,
-                  name: app.name,
-                  description: app.description,
-                  category: app.category,
+                  id: app.app.id,
+                  name: app.app.name,
+                  description: app.app.description,
+                  category: app.app.category,
+                  upvotes: app.upvoteCount,
                 };
                 return <AppCard key={item.id} app={item} />;
               })}

--- a/app/dashboard/apps/me/table.tsx
+++ b/app/dashboard/apps/me/table.tsx
@@ -4,13 +4,30 @@ import { ColumnDef } from "@tanstack/react-table";
 import clsx from "clsx";
 import { InferSelectModel } from "drizzle-orm";
 
-export const columns: ColumnDef<InferSelectModel<typeof apps>>[] = [
+type AppWithUpvotes = {
+  app: InferSelectModel<typeof apps>;
+  upvoteCount: number;
+};
+
+export const columns: ColumnDef<AppWithUpvotes>[] = [
   {
-    accessorKey: "name",
+    accessorKey: "app.name",
     header: "App Name",
   },
   {
-    accessorKey: "status",
+    accessorKey: "upvoteCount",
+    header: "Upvotes",
+    cell: ({ getValue }) => {
+      const count = getValue() as number;
+      return (
+        <div className="flex items-center gap-1">
+          <span className="font-medium">{count}</span>
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "app.status",
     header: "Status",
     cell: ({ getValue }) => {
       const status = getValue() as string;

--- a/components/custom/app-card.tsx
+++ b/components/custom/app-card.tsx
@@ -1,14 +1,15 @@
 "use client";
 
+import { Badge } from "@/components/ui/badge";
+import { Heart } from "lucide-react";
 import Link from "next/link";
-import { Star, Users, ExternalLink } from "lucide-react";
-import { Badge } from "../ui/badge";
 
 export interface AppCardProps {
   id: string;
   name: string;
   description: string;
   category: string;
+  upvotes: number;
 }
 
 export default function AppCard({ app }: { app: AppCardProps }) {
@@ -35,15 +36,13 @@ export default function AppCard({ app }: { app: AppCardProps }) {
         </p>
 
         <div className="flex items-center justify-between pt-4 border-t border-border">
-          <div className="flex items-center gap-1">
-            <Star className="w-4 h-4 text-secondary fill-secondary" />
-            <span className="text-sm font-semibold">0.0</span>
+          <div className="flex items-center gap-1"></div>
+          <div className="flex items-center gap-1 text-muted-foreground"></div>
+          <div className="flex gap-5">
+            <p className="text-foreground/50">upvotes</p>
+            <Heart className="text-destructive fill-destructive size-5 mt-0.5 -mr-3" />
+            <p className="text-foreground/50">{app.upvotes}</p>
           </div>
-          <div className="flex items-center gap-1 text-muted-foreground">
-            <Users className="w-4 h-4" />
-            <span className="text-sm">0</span>
-          </div>
-          <ExternalLink className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
         </div>
       </div>
     </Link>

--- a/db/migrations/0005_nostalgic_devos.sql
+++ b/db/migrations/0005_nostalgic_devos.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "upvote" (
+	"userId" text NOT NULL,
+	"appId" text NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "upvote_userId_appId_pk" PRIMARY KEY("userId","appId")
+);
+--> statement-breakpoint
+ALTER TABLE "upvote" ADD CONSTRAINT "upvote_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "upvote" ADD CONSTRAINT "upvote_appId_app_id_fk" FOREIGN KEY ("appId") REFERENCES "public"."app"("id") ON DELETE cascade ON UPDATE no action;

--- a/db/migrations/meta/0005_snapshot.json
+++ b/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,632 @@
+{
+  "id": "2c14b0b6-92fc-4f42-aa78-5d48c70dadc0",
+  "prevId": "b52c1c80-52ad-4922-8734-d55b93f07b7e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app": {
+      "name": "app",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverImage": {
+          "name": "coverImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websiteUrl": {
+          "name": "websiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repoUrl": {
+          "name": "repoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demoUrl": {
+          "name": "demoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "builtWith": {
+          "name": "builtWith",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "AppStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_userId_user_id_fk": {
+          "name": "app_userId_user_id_fk",
+          "tableFrom": "app",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_slug_unique": {
+          "name": "app_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_providerId_idx": {
+          "name": "accounts_providerId_idx",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote": {
+      "name": "upvote",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "upvote_userId_user_id_fk": {
+          "name": "upvote_userId_user_id_fk",
+          "tableFrom": "upvote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "upvote_appId_app_id_fk": {
+          "name": "upvote_appId_app_id_fk",
+          "tableFrom": "upvote",
+          "tableTo": "app",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "upvote_userId_appId_pk": {
+          "name": "upvote_userId_appId_pk",
+          "columns": [
+            "userId",
+            "appId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayUsername": {
+          "name": "displayUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AppStatus": {
+      "name": "AppStatus",
+      "schema": "public",
+      "values": [
+        "draft",
+        "archived",
+        "published"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1762758272973,
       "tag": "0004_opposite_selene",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1762869357873,
+      "tag": "0005_nostalgic_devos",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schemas/app.ts
+++ b/db/schemas/app.ts
@@ -1,5 +1,6 @@
 import { appStatusEnum } from "@/db/schemas/enums";
 import { timestamps } from "@/db/schemas/timestamps";
+import { upvotes } from "@/db/schemas/upvote";
 import { users } from "@/db/schemas/user";
 import { relations } from "drizzle-orm";
 import { boolean, integer, pgTable, text } from "drizzle-orm/pg-core";
@@ -27,9 +28,10 @@ export const apps = pgTable("app", {
   ...timestamps,
 });
 
-export const appsRelations = relations(apps, ({ one }) => ({
+export const appsRelations = relations(apps, ({ one, many }) => ({
   user: one(users, {
     fields: [apps.userId],
     references: [users.id],
   }),
+  upvotes: many(upvotes),
 }));

--- a/db/schemas/upvote.ts
+++ b/db/schemas/upvote.ts
@@ -1,0 +1,30 @@
+import { apps } from "@/db/schemas/app";
+import { timestamps } from "@/db/schemas/timestamps";
+import { users } from "@/db/schemas/user";
+import { relations } from "drizzle-orm";
+import { pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+
+export const upvotes = pgTable(
+  "upvote",
+  {
+    userId: text("userId")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    appId: text("appId")
+      .notNull()
+      .references(() => apps.id, { onDelete: "cascade" }),
+    ...timestamps,
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.appId] })],
+);
+
+export const upvotesRelations = relations(upvotes, ({ one }) => ({
+  user: one(users, {
+    fields: [upvotes.userId],
+    references: [users.id],
+  }),
+  app: one(apps, {
+    fields: [upvotes.appId],
+    references: [apps.id],
+  }),
+}));

--- a/db/schemas/user.ts
+++ b/db/schemas/user.ts
@@ -1,6 +1,9 @@
+import { apps } from "@/db/schemas/app";
 import { userRoleEnum } from "@/db/schemas/enums";
 import { timestamps } from "@/db/schemas/timestamps";
+import { upvotes } from "@/db/schemas/upvote";
 import { createId } from "@paralleldrive/cuid2";
+import { relations } from "drizzle-orm";
 import { boolean, pgTable, text } from "drizzle-orm/pg-core";
 
 export const users = pgTable("user", {
@@ -16,3 +19,8 @@ export const users = pgTable("user", {
   displayUsername: text("displayUsername").notNull(),
   ...timestamps,
 });
+
+export const usersRelations = relations(users, ({ many }) => ({
+  apps: many(apps),
+  upvotes: many(upvotes),
+}));

--- a/server/upvote.ts
+++ b/server/upvote.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { db } from "@/db";
+import { upvotes } from "@/db/schemas/upvote";
+import { getUserFromAuth } from "@/server/user";
+import { and, eq } from "drizzle-orm";
+
+export async function toggleUpvote({
+  appId,
+}: {
+  appId: string;
+}): Promise<{ success: boolean; action: "removed" | "added" }> {
+  try {
+    if (!appId) {
+      throw new Error("Invalid app ID");
+    }
+
+    const user = await getUserFromAuth();
+
+    const existingUpvote = await db
+      .select()
+      .from(upvotes)
+      .where(and(eq(upvotes.userId, user.id), eq(upvotes.appId, appId)));
+
+    if (existingUpvote.length >= 1) {
+      await db
+        .delete(upvotes)
+        .where(and(eq(upvotes.userId, user.id), eq(upvotes.appId, appId)));
+
+      return { success: true, action: "removed" };
+    } else {
+      await db.insert(upvotes).values({ appId, userId: user.id });
+      return { success: true, action: "added" };
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(error.message);
+    }
+
+    throw new Error("Failed to change upvote status");
+  }
+}
+
+export async function checkUserUpvote({
+  appId,
+}: {
+  appId: string;
+}): Promise<{ hasUpvoted: boolean }> {
+  try {
+    if (!appId) {
+      throw new Error("Invalid app ID");
+    }
+
+    const user = await getUserFromAuth();
+
+    const existingUpvote = await db
+      .select()
+      .from(upvotes)
+      .where(and(eq(upvotes.userId, user.id), eq(upvotes.appId, appId)));
+
+    if (existingUpvote.length >= 1) {
+      return { hasUpvoted: true };
+    } else {
+      return { hasUpvoted: false };
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(error.message);
+    }
+
+    throw new Error("Failed to fetch upvote status");
+  }
+}


### PR DESCRIPTION
Add database relations and migration, server queries that return upvote counts, and client changes to display and toggle upvotes. Updates include useQueries/useMutation in app details, toast feedback, app card and dashboard table adjustments to surface counts.